### PR TITLE
fix(holdSubject): Fix holdSubject to buffer without consumer

### DIFF
--- a/src/HoldSubjectSource.ts
+++ b/src/HoldSubjectSource.ts
@@ -25,9 +25,12 @@ export class HoldSubjectSource<T> extends BasicSubjectSource<T> {
   }
 
   next (value: T) {
-    if (!this.active || this.scheduler === void 0) { return; }
+    if (this.scheduler === void 0) { return; }
     const time = this.scheduler.now();
     this.buffer = dropAndAppend({time, value}, this.buffer, this.bufferSize);
-    this._next(time, value);
+
+    if (this.active) {
+      this._next(time, value);
+    }
   }
 }

--- a/test/holdSubject.js
+++ b/test/holdSubject.js
@@ -9,24 +9,36 @@ describe('holdSubject', () => {
     })
   })
 
-  it('should replay the last value', () => {
+  it('should buffer with consumer and replay last value', () => {
     const stream = holdSubject()
+
+    stream.observe(() => {})
+
     stream.next(1)
     stream.next(2)
 
-    setTimeout(() => stream.complete(), 10)
+    setTimeout(() => stream.complete())
 
-    return stream.forEach(x => {
-      assert.strictEqual(x, 2)
-    })
+    return stream
+      .reduce((x, y) => x.concat(y), [])
+      .then(x => assert.deepEqual(x, [ 2 ]))
+  })
 
+  it('should buffer without consumer and replay last value', () => {
+    const stream = holdSubject()
+
+    stream.next(1)
+    stream.next(2)
+
+    setTimeout(() => stream.complete())
+
+    return stream
+      .reduce((x, y) => x.concat(y), [])
+      .then(x => assert.deepEqual(x, [ 2 ]))
   })
 
   it('should allow for adjusting bufferSize of stream', () => {
     const stream = holdSubject(3)
-
-    // Add an observer so the stream begins buffering events
-    stream.observe(() => {})
 
     stream.next(1)
     stream.next(2)
@@ -40,6 +52,5 @@ describe('holdSubject', () => {
       .then(x => {
         assert.deepEqual(x, [2, 3, 4])
       })
-
   })
 })


### PR DESCRIPTION
In previous 4.x releases, holdSubject buffered events regardless of whether it had a consumer. I noticed this was changed incidentally by my recent fix to another issue, but I left the changed behavior because I believed that is how `@most/hold` behaved. In addition, the changed behavior was not communicated clearly, so a major change in API behavior slipped into 4.x.

This should be fixed for two reasons:

1. To reverse a breaking change to the 4.x version
2. Because subjects differ from regular streams in that subjects always have a producer while normal streams only have a producer when they have a consumer. Since events can be produced without an active consumer, `holdSubject` should buffer events regardless of consumer. I believe this is the more intuitive behavior as well. (Thanks to @briancavalier for calling out this distinction)